### PR TITLE
feat(iteration add Repeat function with tests and justfile task

### DIFF
--- a/iteration/repeat.go
+++ b/iteration/repeat.go
@@ -1,0 +1,12 @@
+package iteration
+
+import "strings"
+
+func Repeat(charactor string, times int) string {
+	var repeated strings.Builder
+
+	for i := 0; i < times; i++ {
+		repeated.WriteString(charactor)
+	}
+	return repeated.String()
+}

--- a/iteration/repeat_test.go
+++ b/iteration/repeat_test.go
@@ -1,0 +1,18 @@
+package iteration
+
+import "testing"
+
+func TestRepeat(t *testing.T) {
+	repeated := Repeat("a", 5)
+	expected := "aaaaa"
+
+	if repeated != expected {
+		t.Errorf("expected %q but got %q", expected, repeated)
+	}
+}
+
+func BenchmarkRepeat(b *testing.B) {
+	for b.Loop() {
+		Repeat("a", 5)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+default:
+     pkgsite -open .


### PR DESCRIPTION
Add Repeat(charactor string, times int) which builds a repeated
string using strings.Builder and a simple loop. Include unit test
TestRepeat verifying expected output and BenchmarkRepeat for basic
performance profiling.

Add a justfile default task to open pkg for quick documentation
.

Fixes: provide reusable iteration helper, test coverage, and a
convenience developer task.