### PR TITLE
array-and-slices

### DIFF
--- a/sum/sum.go
+++ b/sum/sum.go
@@ -1,0 +1,8 @@
+package sum
+
+func Sum(nubmers [5]int) (sum int) {
+	for _, number := range nubmers {
+		sum += number
+	}
+	return
+}

--- a/sum/sum.go
+++ b/sum/sum.go
@@ -1,8 +1,35 @@
 package sum
 
-func Sum(nubmers [5]int) (sum int) {
-	for _, number := range nubmers {
+func Sum(numbers []int) (sum int) {
+
+	for _, number := range numbers {
 		sum += number
+	}
+
+	return
+}
+
+func SumAll(numbersToSum ...[]int) (sums []int) {
+
+	for _, numbers := range numbersToSum {
+		sums = append(sums, Sum(numbers))
+	}
+
+	return
+}
+
+func SumAllTails(numbersToSumTails ...[]int) (sums []int) {
+	for _, numbers := range numbersToSumTails {
+
+		var tail []int
+
+		if len(numbers) < 2 {
+			tail = []int{0}
+		} else {
+			tail = numbers[1:]
+		}
+
+		sums = append(sums, Sum(tail))
 	}
 	return
 }

--- a/sum/sum_test.go
+++ b/sum/sum_test.go
@@ -1,14 +1,63 @@
 package sum
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestSum(t *testing.T) {
-	numbers := [5]int{1, 2, 3, 4, 5}
+	t.Run("collection of 5 numbers", func(t *testing.T) {
+		numbers := []int{1, 2, 3, 4, 5}
 
-	got := Sum(numbers)
-	want := 15
+		got := Sum(numbers)
+		want := 15
 
-	if got != want {
-		t.Errorf("got %d %d given, %v", got, want, numbers)
+		if got != want {
+			t.Errorf("got %d want %d, %v", got, want, numbers)
+		}
+	})
+
+	t.Run("collection of any size", func(t *testing.T) {
+		numbers := []int{1, 2, 3}
+
+		got := Sum(numbers)
+		want := 6
+
+		if got != want {
+			t.Errorf("got %d want %d, %v", got, want, numbers)
+		}
+	})
+
+}
+
+func TestSumAll(t *testing.T) {
+	got := SumAll([]int{1, 2}, []int{0, 9})
+	want := []int{3, 9}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v want %v", got, want)
 	}
+}
+
+func TestSumAllTails(t *testing.T) {
+	checkSums := func(t testing.TB, got, want []int) {
+		t.Helper()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v want %v", got, want)
+		}
+	}
+
+	t.Run("make the sums of some slices",
+		func(t *testing.T) {
+			got := SumAllTails([]int{1, 2}, []int{0, 9})
+			want := []int{2, 9}
+			checkSums(t, got, want)
+		})
+
+	t.Run("safely sum empty slices", func(t *testing.T) {
+		got := SumAllTails([]int{}, []int{3, 4, 5})
+		want := []int{0, 9}
+
+		checkSums(t, got, want)
+	})
 }

--- a/sum/sum_test.go
+++ b/sum/sum_test.go
@@ -1,0 +1,14 @@
+package sum
+
+import "testing"
+
+func TestSum(t *testing.T) {
+	numbers := [5]int{1, 2, 3, 4, 5}
+
+	got := Sum(numbers)
+	want := 15
+
+	if got != want {
+		t.Errorf("got %d %d given, %v", got, want, numbers)
+	}
+}


### PR DESCRIPTION
- Change Sum to accept a slice instead of a fixed-size array, allowing summing collections of any length.
- Add SumAll to compute sums for multiple slices at once.
- Add SumAllTails to sum only the tails of provided slices, treating empty or single-element slices as having a tail sum of 0.
- Replace/extend tests to cover varying slice sizes, SumAll results, and SumAllTails behavior (including empty slices) with helper assertions using reflect.DeepEqual.